### PR TITLE
Improve error handling

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
-# fail if any commands fails
+# fail if any commands fail
 set -e
 # debug log
 if [ "${show_debug_logs}" == "yes" ]; then
   set -x
 fi
 
-function getToken()
-{
-  printf "\n\nObtaining a Token\n"  
-  
-  curl --silent -X POST \
+function getToken() {
+  printf "\n\nObtaining a Token...\n"
+
+  response=$(curl --silent -X POST \
     https://connect-api.cloud.huawei.com/api/oauth2/v1/token \
     -H 'Content-Type: application/json' \
     -H 'cache-control: no-cache' \
@@ -18,65 +17,105 @@ function getToken()
       "grant_type": "client_credentials",
       "client_id": "'${huawei_client_id}'",
       "client_secret": "'${huawei_client_secret}'"
-  }' > token.json
+  }' || true)
 
-  printf "\nObtaining a Token ✅\n"
-} 
+  if [[ -z "$response" ]]; then
+    printf "\n ❌ Failed to obtain a token. Check your network connection and credentials 😢\n"
+    exit 1 
+  fi
 
-function getFileUploadUrl()
-{
-  ACCESS_TOKEN=`jq -r '.access_token' token.json`
-  FILE_EXT="${file_path##*.}"
-  RELEASE_TYPE=$( getReleaseTypeValue ) 
+  echo "$response" >token.json
 
-  printf "\nObtaining the File Upload URL\n"
+  CODE=$(jq -r '.ret.code' token.json)
+  if [ "${CODE}" != "null" ] &&  [ "${CODE}" != "0" ]; then
+    printf "\n ❌ Failed to obtain a token 😢\n"
+    echo "$response"
+    exit 1
+  fi
 
-  curl --silent -X GET \
-  'https://connect-api.cloud.huawei.com/api/publish/v2/upload-url?appId='"${huawei_app_id}"'&suffix='"${FILE_EXT}"'&releaseType='"${RELEASE_TYPE}" \
-  -H 'Authorization: Bearer '"${ACCESS_TOKEN}"'' \
-  -H 'client_id: '"${huawei_client_id}"'' > uploadurl.json
-
-  printf "\nObtaining the File Upload URL ✅\n"
+  printf "Obtaining a Token ✅\n"
 }
 
-function getReleaseTypeValue()
-{
+function getFileUploadUrl() {
+  ACCESS_TOKEN=$(jq -r '.access_token' token.json)
+  FILE_EXT="${file_path##*.}"
+  RELEASE_TYPE=$(getReleaseTypeValue)
+
+  printf "\nObtaining the File Upload URL...\n"
+
+  response=$(curl --silent -X GET \
+    'https://connect-api.cloud.huawei.com/api/publish/v2/upload-url?appId='"${huawei_app_id}"'&suffix='"${FILE_EXT}"'&releaseType='"${RELEASE_TYPE}" \
+    -H 'Authorization: Bearer '"${ACCESS_TOKEN}"'' \
+    -H 'client_id: '"${huawei_client_id}"'' || true)
+
+  if [[ -z "$response" ]]; then
+    printf "\n ❌ Failed to obtain the file upload URL. Check your network connection and parameters 😢\n"
+    exit 1
+  fi
+
+  echo "$response" >uploadurl.json
+
+  CODE=$(jq -r '.ret.code' uploadurl.json)
+  if [ "${CODE}" != "null" ] &&  [ "${CODE}" != "0" ]; then
+    printf "\n ❌ Failed to obtain the file upload URL. 😢\n"
+    echo "$response"
+    exit 1
+  fi
+
+  printf "Obtaining the File Upload URL ✅\n"
+}
+
+function getReleaseTypeValue() {
   if [ "${release_type}" == "By Phase" ]; then
-     releaseTypeValue=3
-  else 
-     releaseTypeValue=1
+    releaseTypeValue=3
+  else
+    releaseTypeValue=1
   fi
 
   echo $releaseTypeValue
 }
 
-function uploadFile()
-{
-  UPLOAD_URL=`jq -r '.uploadUrl' uploadurl.json`
-  UPLOAD_AUTH_CODE=`jq -r '.authCode' uploadurl.json` 
+function uploadFile() {
+  UPLOAD_URL=$(jq -r '.uploadUrl' uploadurl.json)
+  UPLOAD_AUTH_CODE=$(jq -r '.authCode' uploadurl.json)
 
-  printf "\nUploading a File\n"
+  printf "\nUploading a File...\n"
 
-  curl --silent -X POST \
+  response=$(curl --silent -X POST \
     "${UPLOAD_URL}" \
     -H 'Accept: application/json' \
     -F authCode="${UPLOAD_AUTH_CODE}" \
     -F fileCount=1 \
     -F parseType=1 \
-    -F file="@${file_path}" > uploadfile.json
-  
-  printf "\nUploading a File ✅\n"  
+    -F file="@${file_path}" || true)
+
+  if [[ -z "$response" ]]; then
+    printf "\n ❌ Failed to upload the file. Check your network connection and file path 😢\n"
+    exit 1
+  fi
+
+  echo "$response" >uploadfile.json
+
+  CODE=$(jq -r '.result.UploadFileRsp.ifSuccess' uploadfile.json)
+  if [ "${CODE}" != "1" ]; then
+    printf "\n ❌ Failed to upload the file.. 😢\n"
+    echo "$response"
+    exit 1
+  fi
+
+
+
+  printf "Uploading a File ✅\n"
 }
 
-function updateAppFileInfo()
-{
-  ACCESS_TOKEN=`jq -r '.access_token' token.json`
-  FILE_DEST_URL=`jq -r '.result.UploadFileRsp.fileInfoList[0].fileDestUlr' uploadfile.json`
-  FILE_SIZE=`jq -r '.result.UploadFileRsp.fileInfoList[0].size' uploadfile.json`
+function updateAppFileInfo() {
+  ACCESS_TOKEN=$(jq -r '.access_token' token.json)
+  FILE_DEST_URL=$(jq -r '.result.UploadFileRsp.fileInfoList[0].fileDestUlr' uploadfile.json)
+  FILE_SIZE=$(jq -r '.result.UploadFileRsp.fileInfoList[0].size' uploadfile.json)
 
-  printf "\nUpdating App File Information - With the previoulsy uploaded file: ${huawei_filename}"
+  printf "\nUpdating App File Information - With the previously uploaded file: '${huawei_filename}'\n"
 
-  curl --silent -X PUT \
+  response=$(curl --silent -X PUT \
     'https://connect-api.cloud.huawei.com/api/publish/v2/app-file-info?appId='"$huawei_app_id"'' \
     -H 'Authorization: Bearer '"${ACCESS_TOKEN}"'' \
     -H 'Content-Type: application/json' \
@@ -90,111 +129,165 @@ function updateAppFileInfo()
         "fileDestUrl":"'"${FILE_DEST_URL}"'",
         "size":"'"${FILE_SIZE}"'"
       }]
-  }' > result.json
+  }' || true)
 
-  printf "\nUpdating App File Information - With the previoulsy uploaded file ✅"
+  if [[ -z "$response" ]]; then
+    printf "\n ❌ Failed to update app file information. Check your network connection and parameters 😢\n"
+    exit 1
+  fi
+  
+  echo "$response" >result.json
+
+  CODE=$(jq -r '.ret.code' result.json)
+  if [ "${CODE}" != "0" ]; then
+    printf "\n ❌ Failed to update app file information 😢\n"
+    echo "$response"
+    exit 1
+  fi
+
+  printf "Updating App File Information - With the previously uploaded file ✅\n"
 }
 
-function submitApp()
-{  
-  ACCESS_TOKEN=`jq -r '.access_token' token.json`
+function submitApp() {
+  ACCESS_TOKEN=$(jq -r '.access_token' token.json)
 
-  if [ "${release_type}" == "By Phase" ] ;then
-      submitAppPhaseMode
-  else  
-      submitAppDirectly
-  fi 
+  if [ "${release_type}" == "By Phase" ]; then
+    submitAppPhaseMode
+  else
+    submitAppDirectly
+  fi
 }
 
-function submitAppPhaseMode()
-{  
-  ACCESS_TOKEN=`jq -r '.access_token' token.json`
-  RELEASE_TYPE=$( getReleaseTypeValue ) 
+function submitAppPhaseMode() {
+  ACCESS_TOKEN=$(jq -r '.access_token' token.json)
+  RELEASE_TYPE=$(getReleaseTypeValue)
   JSON_STRING="{\"phasedReleaseStartTime\":\"$phase_release_start_time+0000\",\"phasedReleaseEndTime\":\"$phase_release_end_time+0000\",\"phasedReleaseDescription\":\"$phase_release_description\",\"phasedReleasePercent\":\"$phase_release_percentage\"}"
 
-  curl --silent -X  POST \
-  'https://connect-api.cloud.huawei.com/api/publish/v2/app-submit?appid='"$huawei_app_id"'&releaseType='"${RELEASE_TYPE}" \
-  -H 'Authorization: Bearer '"${ACCESS_TOKEN}"'' \
-  -H 'Content-Type: application/json' \
-  -H 'client_id: '"${huawei_client_id}"'' \
-  -d  "${JSON_STRING}" > resultSubmission.json
-} 
+  printf "\nSubmitting the app in phased release mode...\n"
 
-function submitAppDirectly()
-{  
-  ACCESS_TOKEN=`jq -r '.access_token' token.json`
+  response=$(curl --silent -X POST \
+    'https://connect-api.cloud.huawei.com/api/publish/v2/app-submit?appid='"$huawei_app_id"'&releaseType='"${RELEASE_TYPE}" \
+    -H 'Authorization: Bearer '"${ACCESS_TOKEN}"'' \
+    -H 'Content-Type: application/json' \
+    -H 'client_id: '"${huawei_client_id}"'' \
+    -d "${JSON_STRING}" || true)
 
-  curl --silent -X  POST \
-  'https://connect-api.cloud.huawei.com/api/publish/v2/app-submit?appid='"$huawei_app_id"'' \
-  -H 'Authorization: Bearer '"${ACCESS_TOKEN}"'' \
-  -H 'client_id: '"${huawei_client_id}"''> resultSubmission.json
+  if [[ -z "$response" ]]; then
+    printf "\n ❌ Failed to submit the app in phased release mode. Check your network connection and parameters 😢\n"
+    exit 1
+  fi
+
+  echo "$response" >resultSubmission.json
 }
 
-function showResponseOrSubmitCompletelyAgain()
-{
-  ACCESS_TOKEN=`jq -r '.access_token' token.json`
-  RET_CODE=`jq -r '.ret.code' resultSubmission.json`
-  RET_MESSAGE=`jq -r '.ret.msg' resultSubmission.json` 
+function submitAppDirectly() {
+  ACCESS_TOKEN=$(jq -r '.access_token' token.json)
 
-  if [[ "${RET_CODE}" == 204144727 ]] ;then
-    getSubmissionStatus  
-    SUBMISSION_STATUS=`jq -r '.aabCompileStatus' resultSubmissionStatus.json`
+  printf "\nSubmitting the app directly...\n"
+
+  response=$(curl --silent -X POST \
+    'https://connect-api.cloud.huawei.com/api/publish/v2/app-submit?appid='"$huawei_app_id"'' \
+    -H 'Authorization: Bearer '"${ACCESS_TOKEN}"'' \
+    -H 'client_id: '"${huawei_client_id}"'' || true)
+
+  if [[ -z "$response" ]]; then
+    printf "\n ❌ Failed to submit the app directly. Check your network connection and parameters 😢\n"
+    exit 1
+  fi
+
+  echo "$response" >resultSubmission.json
+}
+
+function getSubmissionStatus() {
+  ACCESS_TOKEN=$(jq -r '.access_token' token.json)
+  PKG_VERSION=$(jq -r '.pkgVersion[0]' result.json)
+
+  printf "\nGetting submission status...\n"
+
+  response=$(curl --silent -X GET \
+    'https://connect-api.cloud.huawei.com/api/publish/v2/aab/complile/status?appId='"${huawei_app_id}"'&pkgVersion='"${PKG_VERSION}"'' \
+    -H 'Authorization: Bearer '"${ACCESS_TOKEN}"'' \
+    -H 'client_id: '"${huawei_client_id}"'' || true)
+
+  if [[ -z "$response" ]]; then
+    printf "\n ❌ Failed to get submission status. Check your network connection and parameters 😢\n"
+    exit 1
+  fi
+
+  echo "$response" >resultSubmissionStatus.json
+}
+
+function showResponseOrSubmitCompletelyAgain() {
+  ACCESS_TOKEN=$(jq -r '.access_token' token.json)
+  RET_CODE=$(jq -r '.ret.code' resultSubmission.json)
+  RET_MESSAGE=$(jq -r '.ret.msg' resultSubmission.json)
+
+  if [[ "${RET_CODE}" == 204144727 ]]; then
+    getSubmissionStatus
+    SUBMISSION_STATUS=$(jq -r '.aabCompileStatus' resultSubmissionStatus.json)
     printf "Submission Status ${SUBMISSION_STATUS}"
     i=0
-    while (( "${SUBMISSION_STATUS}" == 1 && i < 16 ));
-    do 
-        sleep 20
-        getSubmissionStatus  
-        SUBMISSION_STATUS=`jq -r '.aabCompileStatus' resultSubmissionStatus.json`
-        printf "\nBuild is currently processing, waiting 20 seconds ⏱️ before trying to submit again...\n" 
-        ((i+=1))
+    while (( "${SUBMISSION_STATUS}" == 1 && i < 16 )); do
+      sleep 20
+      getSubmissionStatus
+      SUBMISSION_STATUS=$(jq -r '.aabCompileStatus' resultSubmissionStatus.json)
+      printf "\nBuild is currently processing, waiting 20 seconds ⏱️ before trying to submit again...\n"
+      ((i+=1))
     done
 
     if [ "${SUBMISSION_STATUS}" == 2 ]; then
-        submitApp 
-        CODE=`jq -r '.ret.code' resultSubmission.json`
-        MESSAGE=`jq -r '.ret.msg' resultSubmission.json`
+      submitApp
+      CODE=$(jq -r '.ret.code' resultSubmission.json)
+      MESSAGE=$(jq -r '.ret.msg' resultSubmission.json)
 
-        printf "\nFinal SubmitRetCode - ${CODE}\n" 
-        printf "\nFinal SubmitRetMessage - ${MESSAGE}\n" 
-    else 
-        printf "\n❌ FAILED to submit the App for Review 😢\n" 
-    fi 
+      printf "\nFinal SubmitRetCode - ${CODE}\n"
+      printf "\nFinal SubmitRetMessage - ${MESSAGE}\n"
+    else
+      printf "\n❌ FAILED to submit the App for Review 😢\n"
+    fi
 
-  elif [[ "${RET_CODE}" == 0 ]] ;then 
-    printf "\n🤩 App SUCCESSFULLY SUBMITTED for Review 🎉🎊\n" 
-  else 
-    printf "\n ❌ FAILED to submit the App for Review 😢\n" 
+  elif [[ "${RET_CODE}" == 0 ]]; then
+    printf "\n🤩 App SUCCESSFULLY SUBMITTED for Review 🎉🎊\n"
+  else
+    printf "\n ❌ FAILED to submit the App for Review 😢\n"
     printf "${RET_MESSAGE}"
   fi
 }
 
-function getSubmissionStatus()
-{
-   ACCESS_TOKEN=`jq -r '.access_token' token.json`
-   PKG_VERSION=`jq -r '.pkgVersion[0]' result.json`
- 
-   curl --silent -X  GET \
-   'https://connect-api.cloud.huawei.com/api/publish/v2/aab/complile/status?appId='"${huawei_app_id}"'&pkgVersion='"${PKG_VERSION}"'' \
+function getSubmissionStatus() {
+  ACCESS_TOKEN=$(jq -r '.access_token' token.json)
+  PKG_VERSION=$(jq -r '.pkgVersion[0]' result.json)
+
+  printf "\nGetting submission status...\n"
+
+  response=$(curl --silent -X GET \
+    'https://connect-api.cloud.huawei.com/api/publish/v2/aab/complile/status?appId='"${huawei_app_id}"'&pkgVersion='"${PKG_VERSION}"'' \
     -H 'Authorization: Bearer '"${ACCESS_TOKEN}"'' \
-    -H 'client_id: '"${huawei_client_id}"''> resultSubmissionStatus.json
-}    
+    -H 'client_id: '"${huawei_client_id}"'' || true)
 
-getToken  
+  if [[ -z "$response" ]]; then
+    printf "\n ❌ Failed to get submission status. Check your network connection and parameters 😢\n"
+    exit 1
+  fi
 
-getFileUploadUrl 
+  echo "$response" >resultSubmissionStatus.json
+}
 
-uploadFile 
+getToken
 
-updateAppFileInfo 
+getFileUploadUrl
 
-printf "\nSubmitting app as a Draft...⏳\n" 
+uploadFile
+
+updateAppFileInfo
+
+printf "\nSubmitting app as a Draft...⏳\n"
 
 if [ "${submit_for_review}" == "true" ]; then
-  submitApp 
-  showResponseOrSubmitCompletelyAgain 
-else 
-  printf "\n🤩 App successfully submitted as a Draft 🎉\n" 
+  submitApp
+  showResponseOrSubmitCompletelyAgain
+else
+  printf "\n🤩 App successfully submitted as a Draft 🎉\n"
 fi
 
 exit 0

--- a/step.sh
+++ b/step.sh
@@ -20,7 +20,7 @@ function getToken() {
   }' || true)
 
   if [[ -z "$response" ]]; then
-    printf "\n ❌ Failed to obtain a token. Check your network connection and credentials 😢\n"
+    printf "\n ❌ Failed to obtain a token from AppGallery Connect. Check your network connection and credentials 😢\n"
     exit 1
   fi
 
@@ -28,7 +28,7 @@ function getToken() {
 
   CODE=$(jq -r '.ret.code' token.json)
   if [ "${CODE}" != "null" ] && [ "${CODE}" != "0" ]; then
-    printf "\n ❌ Failed to obtain a token 😢\n"
+    printf "\n ❌ Failed to obtain a token from AppGallery Connect 😢\n. Please check response for details.\n"
     echo "$response"
     exit 1
   fi

--- a/step.sh
+++ b/step.sh
@@ -82,8 +82,8 @@ function uploadFile() {
   printf "\nUploading a File...\n"
 
   
-  if [ ! -f "$filename" ]; then
-      printf "\n ❌ File '$filename' does not exist 😢\n"
+  if [ ! -f "$file_path" ]; then
+      printf "\n ❌ File '$file_path' does not exist 😢\n"
       exit 1
   fi
 

--- a/step.sh
+++ b/step.sh
@@ -81,6 +81,12 @@ function uploadFile() {
 
   printf "\nUploading a File...\n"
 
+  
+  if [ ! -e "$filename" ]; then
+      printf "\n ❌ File '$filename' does not exist 😢\n"
+      exit 1
+  fi
+
   response=$(curl --silent -X POST \
     "${UPLOAD_URL}" \
     -H 'Accept: application/json' \

--- a/step.sh
+++ b/step.sh
@@ -81,10 +81,9 @@ function uploadFile() {
 
   printf "\nUploading a File...\n"
 
-  
   if [ ! -f "$file_path" ]; then
-      printf "\n ❌ File '$file_path' does not exist 😢\n"
-      exit 1
+    printf "\n ❌ File '$file_path' does not exist 😢\n"
+    exit 1
   fi
 
   response=$(curl --silent -X POST \
@@ -129,7 +128,7 @@ function updateAppFileInfo() {
     "fileType":"5",
     "files":[
       {
-        "fileName":"'${huawei_filename}'",
+        "fileName":"'"$huawei_filename"'",
         "fileDestUrl":"'"${FILE_DEST_URL}"'",
         "size":"'"${FILE_SIZE}"'"
       }]

--- a/step.sh
+++ b/step.sh
@@ -21,13 +21,13 @@ function getToken() {
 
   if [[ -z "$response" ]]; then
     printf "\n ❌ Failed to obtain a token. Check your network connection and credentials 😢\n"
-    exit 1 
+    exit 1
   fi
 
   echo "$response" >token.json
 
   CODE=$(jq -r '.ret.code' token.json)
-  if [ "${CODE}" != "null" ] &&  [ "${CODE}" != "0" ]; then
+  if [ "${CODE}" != "null" ] && [ "${CODE}" != "0" ]; then
     printf "\n ❌ Failed to obtain a token 😢\n"
     echo "$response"
     exit 1
@@ -56,7 +56,7 @@ function getFileUploadUrl() {
   echo "$response" >uploadurl.json
 
   CODE=$(jq -r '.ret.code' uploadurl.json)
-  if [ "${CODE}" != "null" ] &&  [ "${CODE}" != "0" ]; then
+  if [ "${CODE}" != "null" ] && [ "${CODE}" != "0" ]; then
     printf "\n ❌ Failed to obtain the file upload URL. 😢\n"
     echo "$response"
     exit 1
@@ -103,8 +103,6 @@ function uploadFile() {
     exit 1
   fi
 
-
-
   printf "Uploading a File ✅\n"
 }
 
@@ -135,7 +133,7 @@ function updateAppFileInfo() {
     printf "\n ❌ Failed to update app file information. Check your network connection and parameters 😢\n"
     exit 1
   fi
-  
+
   echo "$response" >result.json
 
   CODE=$(jq -r '.ret.code' result.json)
@@ -227,12 +225,12 @@ function showResponseOrSubmitCompletelyAgain() {
     SUBMISSION_STATUS=$(jq -r '.aabCompileStatus' resultSubmissionStatus.json)
     printf "Submission Status ${SUBMISSION_STATUS}"
     i=0
-    while (( "${SUBMISSION_STATUS}" == 1 && i < 16 )); do
+    while (("${SUBMISSION_STATUS}" == 1 && i < 16)); do
       sleep 20
       getSubmissionStatus
       SUBMISSION_STATUS=$(jq -r '.aabCompileStatus' resultSubmissionStatus.json)
       printf "\nBuild is currently processing, waiting 20 seconds ⏱️ before trying to submit again...\n"
-      ((i+=1))
+      ((i += 1))
     done
 
     if [ "${SUBMISSION_STATUS}" == 2 ]; then

--- a/step.sh
+++ b/step.sh
@@ -82,7 +82,7 @@ function uploadFile() {
   printf "\nUploading a File...\n"
 
   
-  if [ ! -e "$filename" ]; then
+  if [ ! -f "$filename" ]; then
       printf "\n ❌ File '$filename' does not exist 😢\n"
       exit 1
   fi

--- a/step.sh
+++ b/step.sh
@@ -20,7 +20,7 @@ function getToken() {
   }' || true)
 
   if [[ -z "$response" ]]; then
-    printf "\n ❌ Failed to obtain a token from AppGallery Connect. Check your network connection and credentials 😢\n"
+    printf "\n ❌ An error occurred while obtaining a token from AppGallery Connect. Check your network connection and your credentials 😢\n"
     exit 1
   fi
 
@@ -28,7 +28,7 @@ function getToken() {
 
   CODE=$(jq -r '.ret.code' token.json)
   if [ "${CODE}" != "null" ] && [ "${CODE}" != "0" ]; then
-    printf "\n ❌ Failed to obtain a token from AppGallery Connect 😢\n. Please check response for details.\n"
+    printf "\n ❌ An error occurred while obtaining a token from AppGallery Connect 😢\n. Please check the response for further details.\n"
     echo "$response"
     exit 1
   fi
@@ -49,7 +49,7 @@ function getFileUploadUrl() {
     -H 'client_id: '"${huawei_client_id}"'' || true)
 
   if [[ -z "$response" ]]; then
-    printf "\n ❌ Failed to obtain the file upload URL. Check your network connection and parameters 😢\n"
+    printf "\n ❌ An error occurred while obtaining the file upload URL. Check your network connection and the parameters used 😢\n"
     exit 1
   fi
 
@@ -57,7 +57,7 @@ function getFileUploadUrl() {
 
   CODE=$(jq -r '.ret.code' uploadurl.json)
   if [ "${CODE}" != "null" ] && [ "${CODE}" != "0" ]; then
-    printf "\n ❌ Failed to obtain the file upload URL. 😢\n"
+    printf "\n ❌ An error occurred while obtaining the file upload URL. 😢\n"
     echo "$response"
     exit 1
   fi
@@ -95,7 +95,7 @@ function uploadFile() {
     -F file="@${file_path}" || true)
 
   if [[ -z "$response" ]]; then
-    printf "\n ❌ Failed to upload the file. Check your network connection and file path 😢\n"
+    printf "\n ❌ An error occurred while uploading the file. Check your network connection and file path 😢\n"
     exit 1
   fi
 
@@ -103,7 +103,7 @@ function uploadFile() {
 
   CODE=$(jq -r '.result.UploadFileRsp.ifSuccess' uploadfile.json)
   if [ "${CODE}" != "1" ]; then
-    printf "\n ❌ Failed to upload the file.. 😢\n"
+    printf "\n ❌ An error occurred while uploading the file.. 😢\n"
     echo "$response"
     exit 1
   fi
@@ -116,7 +116,7 @@ function updateAppFileInfo() {
   FILE_DEST_URL=$(jq -r '.result.UploadFileRsp.fileInfoList[0].fileDestUlr' uploadfile.json)
   FILE_SIZE=$(jq -r '.result.UploadFileRsp.fileInfoList[0].size' uploadfile.json)
 
-  printf "\nUpdating App File Information - With the previously uploaded file: '${huawei_filename}'\n"
+  printf "\nUpdating the App File Information with the previous uploaded file: '${huawei_filename}'\n"
 
   response=$(curl --silent -X PUT \
     'https://connect-api.cloud.huawei.com/api/publish/v2/app-file-info?appId='"$huawei_app_id"'' \
@@ -135,7 +135,7 @@ function updateAppFileInfo() {
   }' || true)
 
   if [[ -z "$response" ]]; then
-    printf "\n ❌ Failed to update app file information. Check your network connection and parameters 😢\n"
+    printf "\n ❌ An error occurred while updating the app file information. Check your network connection and the parameters used😢\n"
     exit 1
   fi
 
@@ -143,12 +143,12 @@ function updateAppFileInfo() {
 
   CODE=$(jq -r '.ret.code' result.json)
   if [ "${CODE}" != "0" ]; then
-    printf "\n ❌ Failed to update app file information 😢\n"
+    printf "\n ❌ An error occurred while updating the app file information 😢\n"
     echo "$response"
     exit 1
   fi
 
-  printf "Updating App File Information - With the previously uploaded file ✅\n"
+  printf "Updating the App File Information with the previous uploaded file ✅\n"
 }
 
 function submitApp() {
@@ -176,7 +176,7 @@ function submitAppPhaseMode() {
     -d "${JSON_STRING}" || true)
 
   if [[ -z "$response" ]]; then
-    printf "\n ❌ Failed to submit the app in phased release mode. Check your network connection and parameters 😢\n"
+    printf "\n ❌ An error occurred while submitting the app in phased release mode. Check your network connection and the parameters used 😢\n"
     exit 1
   fi
 
@@ -194,7 +194,7 @@ function submitAppDirectly() {
     -H 'client_id: '"${huawei_client_id}"'' || true)
 
   if [[ -z "$response" ]]; then
-    printf "\n ❌ Failed to submit the app directly. Check your network connection and parameters 😢\n"
+    printf "\n ❌ An error occurred while directly submitting the app. Check your network connection and the parameters used 😢\n"
     exit 1
   fi
 
@@ -205,7 +205,7 @@ function getSubmissionStatus() {
   ACCESS_TOKEN=$(jq -r '.access_token' token.json)
   PKG_VERSION=$(jq -r '.pkgVersion[0]' result.json)
 
-  printf "\nGetting submission status...\n"
+  printf "\nGetting the submission status...\n"
 
   response=$(curl --silent -X GET \
     'https://connect-api.cloud.huawei.com/api/publish/v2/aab/complile/status?appId='"${huawei_app_id}"'&pkgVersion='"${PKG_VERSION}"'' \
@@ -213,7 +213,7 @@ function getSubmissionStatus() {
     -H 'client_id: '"${huawei_client_id}"'' || true)
 
   if [[ -z "$response" ]]; then
-    printf "\n ❌ Failed to get submission status. Check your network connection and parameters 😢\n"
+    printf "\n ❌ An error occurred while getting the submission status. Check your network connection and the parameters used😢\n"
     exit 1
   fi
 
@@ -234,7 +234,7 @@ function showResponseOrSubmitCompletelyAgain() {
       sleep 20
       getSubmissionStatus
       SUBMISSION_STATUS=$(jq -r '.aabCompileStatus' resultSubmissionStatus.json)
-      printf "\nBuild is currently processing, waiting 20 seconds ⏱️ before trying to submit again...\n"
+      printf "\nThe Build is currently processing, waiting 20 seconds ⏱️ before trying to submit again...\n"
       ((i += 1))
     done
 
@@ -269,7 +269,7 @@ function getSubmissionStatus() {
     -H 'client_id: '"${huawei_client_id}"'' || true)
 
   if [[ -z "$response" ]]; then
-    printf "\n ❌ Failed to get submission status. Check your network connection and parameters 😢\n"
+    printf "\n ❌ An error occurred while getting the submission status. Check your network connection and the parameters used 😢\n"
     exit 1
   fi
 
@@ -290,7 +290,7 @@ if [ "${submit_for_review}" == "true" ]; then
   submitApp
   showResponseOrSubmitCompletelyAgain
 else
-  printf "\n🤩 App successfully submitted as a Draft 🎉\n"
+  printf "\n🤩 Your app was successfully submitted as a Draft 🎉\n"
 fi
 
 exit 0


### PR DESCRIPTION
The script did not handle failing requests and just continued. This made it hard to debug errors.
Now the script:

- Stops after a request failed
- Prints the error response

Example:

```
Obtaining a Token...

 ❌ Failed to obtain a token 😢
{"ret":{"code":203890688,"msg":"[AppGalleryConnectApiPermissionService]client id or secret error"},"products":[],"permissions":[],"urlLimit":[]}
```

```
  Obtaining a Token...
  Obtaining a Token ✅
  
  Obtaining the File Upload URL...
  Obtaining the File Upload URL ✅
  
  Uploading a File...
  Uploading a File ✅
  
  Updating App File Information - With the previously uploaded file: ''
  
   ❌ Failed to update app file information 😢
  {"ret":{"code":204144641,"msg":"[AppGalleryConnectPublishService]The fileName is invalid!"}}
```