### PR TITLE
Fixes the query parameters for the compile/status request

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -208,7 +208,7 @@ function getSubmissionStatus() {
   printf "\nGetting the submission status...\n"
 
   response=$(curl --silent -X GET \
-    'https://connect-api.cloud.huawei.com/api/publish/v2/aab/complile/status?appId='"${huawei_app_id}"'&pkgVersion='"${PKG_VERSION}"'' \
+    'https://connect-api.cloud.huawei.com/api/publish/v2/aab/complile/status?appId='"${huawei_app_id}"'&pkgIds='"${PKG_VERSION}"'' \
     -H 'Authorization: Bearer '"${ACCESS_TOKEN}"'' \
     -H 'client_id: '"${huawei_client_id}"'' || true)
 
@@ -264,7 +264,7 @@ function getSubmissionStatus() {
   printf "\nGetting submission status...\n"
 
   response=$(curl --silent -X GET \
-    'https://connect-api.cloud.huawei.com/api/publish/v2/aab/complile/status?appId='"${huawei_app_id}"'&pkgVersion='"${PKG_VERSION}"'' \
+    'https://connect-api.cloud.huawei.com/api/publish/v2/aab/complile/status?appId='"${huawei_app_id}"'&pkgIds='"${PKG_VERSION}"'' \
     -H 'Authorization: Bearer '"${ACCESS_TOKEN}"'' \
     -H 'client_id: '"${huawei_client_id}"'' || true)
 


### PR DESCRIPTION
**Context**:
We are experiencing a failure during the deploy process. The submission is failing even though the application update is created.

`+ SUBMISSION_STATUS=null
+ printf 'Submission Status null'
Submission Status null+ i=0
+ ((  null == 1 && i < 16  ))
+ '[' null == 2 ']'
+ printf '\n❌ FAILED to submit the App for Review 😢\n'
❌ FAILED to submit the App for Review 😢
+ exit 0`

Checking the code, we noticed that the status api request was failing so the step does not perform the app submission.

**SOLUTION**

Testing the api using Postman we are getting this message:
`{
    "message": "Parameter is not valid for operation [AppGalleryConnectPublishService.publish-services.getPackageCompileStatus]. Parameter is [pkgIds]. Processor is [query]."
}`

So as the huawei documentation points out (https://developer.huawei.com/consumer/en/doc/development/AppGallery-connect-References/agcapi-query-aabfile-0000001111685206), the proper name for the second query paremeter in the status method is pkgIds. Tested using postman, the change works fine.

```
{
    "ret": {
        "code": 0,
        "msg": "success"
    },
    "pkgStateList": [
        {
            "pkgId": "XXXXXXXXXXXX",
            "aabCompileStatus": 0,
            "successStatus": 0
        }
    ]
}
```

